### PR TITLE
Elixlsx Fork - Patch issue with nil/empty cells unable to be styled

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Elixlsx
 
+> ### Rum&Code
+> ℹ️ This repo is a fork of [xou/elixlsx](https://github.com/xou/elixlsx/tree/master) to fix some of the shortcomings with the original library.
+> #### Changelog & differences
+> - Fix issue where passing `nil` to a cell's content ignores that cell's styling & formatting props
+>   - Add missing pattern in Elixlsx.Util.to_excel_datetime/1 to support empty cells
+
 [![Build Status](https://travis-ci.com/xou/elixlsx.svg?branch=master)](https://travis-ci.org/xou/elixlsx)
 [![Module Version](https://img.shields.io/hexpm/v/elixlsx.svg)](https://hex.pm/packages/elixlsx)
 [![Hex Docs](https://img.shields.io/badge/hex-docs-lightgreen.svg)](https://hexdocs.pm/elixlsx/)

--- a/lib/elixlsx/util.ex
+++ b/lib/elixlsx/util.ex
@@ -230,6 +230,9 @@ defmodule Elixlsx.Util do
   def to_excel_datetime({:formula, value}) do
     {:formula, value}
   end
+  
+  @spec to_excel_datetime(any()) :: any()
+  def to_excel_datetime(value), do: value
 
   @doc ~S"""
   Replace_all(input, [{search, replace}]).

--- a/lib/elixlsx/xml_templates.ex
+++ b/lib/elixlsx/xml_templates.ex
@@ -221,68 +221,64 @@ defmodule Elixlsx.XMLTemplates do
       |> List.foldl({"", 1}, fn cell, {acc, colidx} ->
         {content, styleID, cellstyle} = split_into_content_style(cell, wci)
 
-        if is_nil(content) do
-          {acc, colidx + 1}
-        else
-          content =
-            if CellStyle.is_date?(cellstyle) do
-              U.to_excel_datetime(content)
-            else
-              content
-            end
+        content =
+          if CellStyle.is_date?(cellstyle) do
+            U.to_excel_datetime(content)
+          else
+            content
+          end
 
-          cv = get_content_type_value(content, wci)
+        cv = get_content_type_value(content, wci)
 
-          {content_type, content_value, content_opts} =
-            case cv do
-              {t, v} ->
-                {t, v, []}
+        {content_type, content_value, content_opts} =
+          case cv do
+            {t, v} ->
+              {t, v, []}
 
-              {t, v, opts} ->
-                {t, v, opts}
+            {t, v, opts} ->
+              {t, v, opts}
 
-              :error ->
-                raise %ArgumentError{
-                  message:
-                    "Invalid column content at " <>
-                      U.to_excel_coords(rowidx, colidx) <> ": " <> inspect(content)
-                }
-            end
+            :error ->
+              raise %ArgumentError{
+                message:
+                  "Invalid column content at " <>
+                  U.to_excel_coords(rowidx, colidx) <> ": " <> inspect(content)
+              }
+          end
 
-          cell_xml =
-            case content_type do
-              :formula ->
-                value =
-                  if not is_nil(content_opts[:value]),
-                    do: "<v>#{content_opts[:value]}</v>",
-                    else: ""
+        cell_xml =
+          case content_type do
+            :formula ->
+              value =
+                if not is_nil(content_opts[:value]),
+                   do: "<v>#{content_opts[:value]}</v>",
+                   else: ""
 
-                """
-                <c r="#{U.to_excel_coords(rowidx, colidx)}"
-                s="#{styleID}">
-                <f>#{content_value}</f>
-                #{value}
-                </c>
-                """
+              """
+              <c r="#{U.to_excel_coords(rowidx, colidx)}"
+              s="#{styleID}">
+              <f>#{content_value}</f>
+              #{value}
+              </c>
+              """
 
-              :empty ->
-                """
-                <c r="#{U.to_excel_coords(rowidx, colidx)}"
-                s="#{styleID}">
-                </c>
-                """
+            :empty ->
+              """
+              <c r="#{U.to_excel_coords(rowidx, colidx)}"
+              s="#{styleID}">
+              </c>
+              """
 
-              type ->
-                """
-                <c r="#{U.to_excel_coords(rowidx, colidx)}"
-                s="#{styleID}" t="#{type}">
-                <v>#{content_value}</v>
-                </c>
-                """
-            end
+            type ->
+              """
+              <c r="#{U.to_excel_coords(rowidx, colidx)}"
+              s="#{styleID}" t="#{type}">
+              <v>#{content_value}</v>
+              </c>
+              """
+          end
 
-          {acc <> cell_xml, colidx + 1}
-        end
+        {acc <> cell_xml, colidx + 1}
       end)
 
     updated_row

--- a/lib/elixlsx/xml_templates.ex
+++ b/lib/elixlsx/xml_templates.ex
@@ -222,6 +222,13 @@ defmodule Elixlsx.XMLTemplates do
         {content, styleID, cellstyle} = split_into_content_style(cell, wci)
 
         content =
+          if is_nil(content) do
+            ""
+          else
+            content
+          end
+
+        content =
           if CellStyle.is_date?(cellstyle) do
             U.to_excel_datetime(content)
           else


### PR DESCRIPTION
## Changes

## What issue?
- Passing `nil` as the contents of a cell specs causes the cell to render unstyled and with no formatting ☹️ 
- Passing `""` is a solution, but raises an error if the cell uses formatting (notably datetime)
- There seems to be [an ongoing PR](https://github.com/xou/elixlsx/pull/151), but it only fixes the issue for DateTime formatting

## Why a fork?
While being aware that forks are generally not desired...
- This repo is being maintained somewhat slowly 🐌 It might take a while before a PR is accepted
- This repo is very mature. If we hit any conflicts, we can assume they won't be very major
- **My experience with the repo isn't enough to feel confident doing a PR to its public repo**
- matter of tradeoffs 🤷‍♂️ 

## Example
Before ❌ 👎 
![image](https://github.com/rum-and-code/elixlsx/assets/31415951/82f4ea9b-2dfb-4126-a6bb-4f8d7324d1b6)

After ✅ 😁 
![image](https://github.com/rum-and-code/elixlsx/assets/31415951/01873dcf-3a03-44b1-88b2-074230a17b5c)
